### PR TITLE
Edited arrow functions to resolve linter errors

### DIFF
--- a/src/challenges.js
+++ b/src/challenges.js
@@ -15,7 +15,7 @@ const limitFunctionCallCount = (cb, n) => {
   // The returned function should only allow `cb` to be invoked `n` times.
 };
 
-const cacheFunction = cb => {
+const cacheFunction = (cb) => {
   // Should return a funciton that invokes `cb`.
   // A cache (object) should be kept in closure scope.
   // The cache should keep track of all arguments have been used to invoke this function.
@@ -27,17 +27,17 @@ const cacheFunction = cb => {
 /* eslint-enable no-unused-vars */
 
 /* ======================== Recursion Practice ============================ */
-const reverseStr = str => {
+const reverseStr = (str) => {
   // reverse str takes in a string and returns that string in reversed order
   // The only difference between the way you've solved this before and now is that you need to do it recursivley!
 };
 
-const checkMatchingLeaves = obj => {
+const checkMatchingLeaves = (obj) => {
   // return true if every property on `obj` is the same
   // otherwise return false
 };
 
-const flatten = elements => {
+const flatten = (elements) => {
   // Flattens a nested array (the nesting can be to any depth).
   // Example: flatten([1, [2], [3, [[4]]]]); => [1, 2, 3, 4];
 };

--- a/tests/challenges.test.js
+++ b/tests/challenges.test.js
@@ -4,7 +4,7 @@ describe('challenges', () => {
   describe('each', () => {
     it('should invoke cb on each array element', () => {
       let count = 0;
-      challengeMethods.each([1, 2, 3], element => {
+      challengeMethods.each([1, 2, 3], (element) => {
         count += element;
       });
       expect(count).toBe(6);


### PR DESCRIPTION
Added parents to arguments in callback functions that were throwing linter errors